### PR TITLE
Fix: Combat Shields Continued Support

### DIFF
--- a/1.4/Patches/VanillaTweaks.xml
+++ b/1.4/Patches/VanillaTweaks.xml
@@ -1,39 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Patch>
-   <!-- Vanilla Tribal Chiefs Dresscode -->
-   <Operation Class="PatchOperationFindMod">
-      <mods>
-         <li>Combat Shields</li>
-      </mods>
-      <match Class="PatchOperationSequence">
-         <operations>
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/PawnKindDef[defName = "Tribal_ChiefMelee"]/apparelTags</xpath>
-               <value>
-			      <apparelTags>
-                    <li>MedievalArmorDecent</li>
-                    <li>MedievalMilitary</li>
-					<li>Shield_Classical</li>
-				  </apparelTags>
-               </value>
-            </li>
-            <li Class="PatchOperationRemove">
-               <xpath>Defs/PawnKindDef[defName = "Tribal_ChiefMelee"]/apparelRequired</xpath>
-            </li>
-         </operations>
-      </match>
-      <nomatch Class="PatchOperationSequence">
-         <operations>
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/PawnKindDef[defName = "Tribal_ChiefMelee"]/apparelRequired</xpath>
-               <value>
-                  <apparelTags>
-                     <li>MedievalArmorDecent</li>
-                     <li>MedievalMilitary</li>
-                  </apparelTags>
-               </value>
-            </li>
-         </operations>
-      </nomatch>
-   </Operation>
+  <!-- Vanilla Tribal Chiefs Dresscode -->
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Combat Shields</li>
+      <li>Combat Shields (Continued)</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName = "Tribal_ChiefMelee"]/apparelTags</xpath>
+          <value>
+            <apparelTags>
+              <li>MedievalArmorDecent</li>
+              <li>MedievalMilitary</li>
+              <li>Shield_Classical</li>
+            </apparelTags>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/PawnKindDef[defName = "Tribal_ChiefMelee"]/apparelRequired</xpath>
+        </li>
+      </operations>
+    </match>
+    <nomatch Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName = "Tribal_ChiefMelee"]/apparelRequired</xpath>
+          <value>
+            <apparelTags>
+              <li>MedievalArmorDecent</li>
+              <li>MedievalMilitary</li>
+            </apparelTags>
+          </value>
+        </li>
+      </operations>
+    </nomatch>
+  </Operation>
 </Patch>


### PR DESCRIPTION
Resolves an issue where if Combat Shields (Continued) is loaded, the Vanilla Armour Expanded patch will cause a Duplicate XML node error since the VAE patch is only looking for "Combat Shields" and if it does not find it, it simply replaces the node `apparelRequired` with `apparelTags` thus causing a duplicate node, whereas Combat Shields (Continued) has its own patch that adds the `apparelTags` node.

Basically the `no-match` class was not checking if `apparelTags` exists or not, and is outright replacing `apparelRequired` with `apparelTags` hence why we get the duplicate node.

I was going to re-write the patch to use dynamic references, but didn't want to impose upon the implementation.

The error that I mentioned:
```
XML error: Duplicate XML node name apparelTags in this XML block: <PawnKindDef ParentName="TribalBase" Name="TribalChiefBase" Abstract="True"><defName>Tribal_ChiefMelee</defName><combatPower>85</combatPower><minGenerationAge>30</minGenerationAge><maxGenerationAge>999</maxGenerationAge><itemQuality>Normal</itemQuality><factionLeader>true</factionLeader><canBeSapper>true</canBeSapper><apparelMoney>450~750</apparelMoney><apparelTags><li>MedievalArmorDecent</li><li>MedievalMilitary</li></apparelTags><requiredWorkTags><li>Violent</li></requiredWorkTags><weaponMoney>500~1000</weaponMoney><initialWillRange>3~5</initialWillRange><initialResistanceRange>19~30</initialResistanceRange><apparelTags><li>Shield_Classical</li></apparelTags></PawnKindDef>
```


Also cleaned up the formatting a bit.